### PR TITLE
Fixes CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           uses: php-actions/composer@v6
           with:
             php_version: ${{ matrix.php-versions }}
-        - name: Check file permissions
-          run: ls -lah
+        - name: Fix file permissions to make vendor writable
+          run: chown -R runner:docker .
         - name: PHPUnit test cases
           run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,7 @@ jobs:
           uses: php-actions/composer@v6
           with:
             php_version: ${{ matrix.php-versions }}
+        - name: Check file permissions
+          run: ls -lah
         - name: PHPUnit test cases
           run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
           with:
             php_version: ${{ matrix.php-versions }}
         - name: Fix file permissions to make vendor writable
-          run: chown -R runner:docker .
+          run: sudo chown -R runner:docker .
         - name: PHPUnit test cases
           run: composer test


### PR DESCRIPTION
The workflow had issues related to file permissions, as the `php-actions/composer` action operates and  creates files as `root`.

This PR fixes it by `chown`ing all files to their expected ownership after dependencies are installed.